### PR TITLE
修改半形符號

### DIFF
--- a/menu.sh
+++ b/menu.sh
@@ -23,7 +23,7 @@ echo ""
 echo "!. 清理目录"
 echo "#. 退出程序"
 echo "*. 关于该工具&帮助"
-echo "￥. 安装依赖"
+echo "¥. 安装依赖"
 
 read -p "请输入选项：" c
 
@@ -49,7 +49,7 @@ elif [ "$c" == "!" ]; then
 	bash ./scripts/clean.sh
 elif [ "$c" == "*" ]; then 
 	bash ./scripts/about.sh
-elif [ "$c" == "￥" ]; then 
+elif [ "$c" == "¥" ]; then 
 	bash ./setup.sh
 else
 	echo "好像输入不正确呢"


### PR DESCRIPTION
大部分的Android 終端機彈出鍵盤時，僅能選取英文（僅提供半形），而非全形。